### PR TITLE
Use hasOwnProperty via Object.prototype

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ module.exports = function mewt (target) {
     },
     get: (_, prop) => {
       if (api[prop]) return api[prop]
-      return target[prop] && (target.hasOwnProperty(prop) ? target[prop] : override(prop))
+      return target[prop] && (Object.prototype.hasOwnProperty.call(target, prop) ? target[prop] : override(prop))
     }
   })
 }


### PR DESCRIPTION
use hasOwnProperty via call, as some object types don't inherit from Object (node 6+ EventEmitter, for example), so the method may not be there.