### PR TITLE
Clone optimization

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 module.exports = function mewt (target) {
   let isA = Array.isArray(target)
     , multiRet = 'push pop shift unshift'
-    , clone = v => (v = isA ? [].concat(v) : Object.assign({}, v), v)
+    , clone = isA ? v => [].concat(v) : v => Object.assign({}, v)
 
   let override = prop => (...args) => {
     let cl = clone(target)


### PR DESCRIPTION
This change moves the check-if-array-or-object check out of the clone method, and does it once at creation time. Since we are talking about immutable structures, it is unnecessary to check each time when cloning if the given object is still of the same type.